### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
   "scripts": {
     "test": "mocha"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hongkongkiwi/nzbget-api.git"
+  },
   "author": "Andy Savage <andy@savage.hk> (http://andy.savage.hk/)",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Had to manually look up the repo on Github.com since without the repository field npm doesn't provide a link to the repo.
